### PR TITLE
Fix not-found status for employee lookup

### DIFF
--- a/MikhailDemo/src/main/java/com/example/MikhailDemo/service/EmployeeServiceImpl.java
+++ b/MikhailDemo/src/main/java/com/example/MikhailDemo/service/EmployeeServiceImpl.java
@@ -6,6 +6,8 @@ import com.example.MikhailDemo.repository.EmployeeRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 @Service
@@ -29,7 +31,10 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Override
     public Employee getEmployeeById(Long id) {
-        return repo.findById(id).orElseThrow(() -> new RuntimeException("Employee not found with id: " + id));
+        return repo.findById(id)
+                .orElseThrow(() ->
+                        new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                "Employee not found with id: " + id));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return HTTP 404 when an employee is not found

## Testing
- `mvnw -q test` *(fails: mvnw: cannot open .mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_684645fcdff883279986324807951054