### PR TITLE
Handle missing employees gracefully

### DIFF
--- a/MikhailDemo/src/main/java/com/example/MikhailDemo/service/EmployeeServiceImpl.java
+++ b/MikhailDemo/src/main/java/com/example/MikhailDemo/service/EmployeeServiceImpl.java
@@ -5,7 +5,9 @@ import com.example.MikhailDemo.entity.Employee;
 import com.example.MikhailDemo.repository.EmployeeRepository;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 import java.util.List;
 
 @Service
@@ -29,7 +31,11 @@ public class EmployeeServiceImpl implements EmployeeService {
 
     @Override
     public Employee getEmployeeById(Long id) {
-        return repo.findById(id).orElseThrow(() -> new RuntimeException("Employee not found with id: " + id));
+        return repo.findById(id)
+                .orElseThrow(() ->
+                        new ResponseStatusException(
+                                HttpStatus.NOT_FOUND,
+                                "Employee not found with id: " + id));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- surface not-found errors with `ResponseStatusException`

## Testing
- `sh ./mvnw test` *(fails: cannot open `.mvn/wrapper/maven-wrapper.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6846477d57bc83278e321742a0c447fe